### PR TITLE
Boundary Node connectivity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 This repository contains useful scripts for Internet Computer Node Providers.
 
-There is presently only one script here: `node_monitor.sh`
+There are presently two scripts here: `node_monitor.sh` and `bn_connectivity.sh`
 
 External contributions are accepted and welcomed. Pull Requests are encouraged!
 
-# Usage:
+# `node_monitor.sh`
+
+This script queries the dashboard to obtain the health status of all nodes
+belonging to the given node provider. It reports all unhealthy nodes.
+
+## Usage:
 
 1. Find your Node Provider Principal ID in the [node_list.txt](./node_list.txt) file.
 
@@ -21,3 +26,26 @@ Example: `vi .env`
     $ ./node_monitor.sh
     All nodes are healthy
 
+# `bn_connectivity.sh`
+
+This script tries to ping all the boundary nodes within the region from which it
+is run. It checks both IPv4 and IPv6 connectivity.
+Note that for a successul node registration only IPv6 connectivity is required.
+
+## Usage:
+
+1. Run the script from a machine within the DC you want to test the connectivity:
+
+    $ ./bn_connectivity.sh
+    => IPv4
+    Pinging 193.118.63.171
+    -> successful
+    Pinging 212.71.124.187
+    -> successful
+
+    => IPv6
+    Pinging 2a0b:21c0:b002:2:5000:edff:fe0d:98de
+    -> successful
+    Pinging 2a00:fb01:400:200:5000:5aff:fef2:9428
+    -> successful
+    Completed connectivity check.

--- a/bn_connectivity.sh
+++ b/bn_connectivity.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -eo pipefail
+
+# This script allows node providers to quickly check if they can reach
+# all the boundary nodes from their region.
+# It does so by pinging all boundary nodes in the region both on IPv4 and IPv6.
+# However, for a succesful node registration only IPv6 is required.
+
+domain="ic0.app"
+
+# Perform DNS lookup for IPv4 and IPv6 addresses
+ipv4_addresses=($(dig A $domain +short))
+ipv6_addresses=($(dig AAAA $domain +short))
+
+# ANSI color codes
+green='\033[0;32m'
+red='\033[0;31m'
+nc='\033[0m'  # No color
+
+function ping_address {
+    ping_cmd=$1
+    address=$2
+    echo -e "Pinging $address"
+    if $ping_cmd -c 4 $address > /dev/null 2>&1; then
+        echo -e "${green}-> successful${nc}"
+    else
+        echo -e "${red}-> failed${nc}"
+    fi
+}
+
+# Check IPv4 connectivity to the boundary nodes
+echo "=> IPv4"
+if [ ${#ipv4_addresses[@]} -gt 0 ]; then
+    for address in "${ipv4_addresses[@]}"; do
+        ping_address ping $address
+    done
+else
+    echo -e "${red}No IPv4 addresses found.${nc}"
+    exit 1
+fi
+echo ""
+
+# Check IPv6 connectivity to the boundary nodes
+echo "=> IPv6"
+if [ ${#ipv6_addresses[@]} -gt 0 ]; then
+    for address in "${ipv6_addresses[@]}"; do
+        ping_address ping6 $address
+    done
+else
+    echo -e "${red}No IPv6 addresses found.${nc}"
+    exit 1
+fi
+
+echo -e "Completed connectivity check."


### PR DESCRIPTION
This PR adds a script allowing node providers to check if they can ping all the boundary nodes within their region.